### PR TITLE
clean up and consolidate library methods / variable storage

### DIFF
--- a/py_trees_viz/gui/html/index.html
+++ b/py_trees_viz/gui/html/index.html
@@ -1,7 +1,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Hello Pixi</title>
+  <title>PyTrees Viz</title>
   <link rel="stylesheet" href="py_trees-0.1.0.css">
 </head>
 <script src="jointjs/dagre-0.8.4.min.js"></script>
@@ -20,7 +20,7 @@
 <body>
   <div id="foo"></div>
   <script type="text/javascript">
-    // Hello to the JS console
+    py_trees.print_versions()
     console.log("Backbone: %s", Backbone.VERSION)
     console.log("Dagre   : %s", dagre.version)
     console.log("Graphlib: %s", graphlib.version)
@@ -31,56 +31,8 @@
   </script>
   <div id="canvas"></div>
   <script type="text/javascript">
-    var graph = new joint.dia.Graph({});
-
-    var paper = new joint.dia.Paper({
-      el: document.getElementById('canvas'),
-      model: graph,
-      width: '100%',
-      height: '100%',
-      // defaultConnector: {  // doesn't seem to have any effect
-      //     name: 'rounded',
-      //     args: {
-      //         radius: 20
-      //     }
-      // },
-      background: { color: '#111111' },
-      // gridSize: 15,     // doesn't work?
-      // drawGrid: {
-      //     name: 'doubleMesh',
-      //     args: [
-      //         { color: '#222222', thickness: 1 }, // settings for the primary mesh
-      //         { color: '#333333', scaleFactor: 5, thickness: 5 } //settings for the secondary mesh
-      // ]}
-    });
-    paper.on('element:mouseover', function(view, event) {
-        // ugh, is there a better way than pulling [0]?
-        //    note; the method used in the view with .find().css({ ... doesn't work
-        view.$box.find('div.html-tooltip')[0].style.display = "block"
-    })
-    paper.on('element:mouseout', function(view, event) {
-        view.$box.find('div.html-tooltip')[0].style.display = "none"
-    })
-    // cell:mousewheel gives strange scale values back (30.0!)
-    paper.on('blank:mousewheel',
-        py_trees.scale_canvas.bind(null, paper)
-    )
-
-    // pan canvas
-    paper.on('blank:pointerdown',
-        py_trees.pan_canvas_begin.bind(null, paper)
-    )
-
-    paper.on('blank:pointermove',
-        py_trees.pan_canvas_move.bind(null, paper)
-    )
-    paper.on('blank:pointerup',
-        py_trees.pan_canvas_move.bind(null, paper)
-    )
-    paper.on('blank:pointerdblclick',
-        py_trees.fit_content_to_canvas.bind(null, paper)
-    )
-
+    graph = new joint.dia.Graph({});
+    paper = py_trees.create_paper({graph: graph})
     tree = py_trees.experiments.create_demo_tree_definition()
     py_trees.update_graph({graph: graph, tree: tree})
     py_trees.layout_graph({graph: graph})

--- a/py_trees_viz/gui/html/index.html
+++ b/py_trees_viz/gui/html/index.html
@@ -86,7 +86,6 @@
     py_trees.layout_graph({graph: graph})
     py_trees.fit_content_to_canvas(paper)
 
-
   </script>
 </body>
 </html>

--- a/py_trees_viz/gui/html/py_trees-0.1.0.js
+++ b/py_trees_viz/gui/html/py_trees-0.1.0.js
@@ -7,7 +7,7 @@
 //   Originally had these in py_trees.shapes, however that replaces
 //   (doesn't combine with) joint.shapes, resulting in a few inconsistent
 //   behaviours when I do call on joint.shapes components (ostensibly
-//   because their views don't get found). 
+//   because their views don't get found).
 // *************************************************************************
 
 var joint = joint
@@ -411,14 +411,16 @@ var py_trees = (function() {
   // *************************************************************************
 
   var _version = '0.1.0'
-  var _links = []
-  var _nodes = {}
-  var _text_blocks = []
+
+  var _foo = function({all_the_things}) {
+    console.log("Inside: " + all_the_things)
+    all_the_things.push(5)
+    console.log("Inside: " + all_the_things)
+  }
 
   var _update_graph = function({graph, tree}) {
     console.log("Adding tree to the graph")
-    _nodes = {}
-    _links = []
+    var _nodes = {}
     for (behaviour in tree.behaviours) {
         // at least name should go through, all others are optional
         node = _create_node({
@@ -442,11 +444,10 @@ var py_trees = (function() {
         if ( typeof tree.behaviours[behaviour].children !== 'undefined') {
             console.log("    Children: " + tree.behaviours[behaviour].children)
             tree.behaviours[behaviour].children.forEach(function (child_id, index) {
-                link = py_trees.create_link({
+                link = _create_link({
                     source: _nodes[tree.behaviours[behaviour].id],
                     target: _nodes[child_id],
                 })
-                _links.push(link)
                 link.addTo(graph)
             });
         }
@@ -470,13 +471,13 @@ var py_trees = (function() {
       attrs: {
           'box': {
               opacity: visited ? 1.0 : 0.3
-            
+
           },
           'type': {
               fill: colour || '#555555',
               opacity: visited ? 1.0 : 0.3
           },
-          
+
       }
     })
     var highlight_colours = {
@@ -493,8 +494,8 @@ var py_trees = (function() {
                 name: 'highlight',
                 args: {
                     color: highlight_colours[status],
-                    width: 2,
-                    opacity: 0.5,
+                    width: 3,
+                    opacity: 0.8,
                     blur: 5
                 }
             }
@@ -511,7 +512,7 @@ var py_trees = (function() {
       var link = new joint.shapes.standard.Link();
       link.source(source)
       link.target(target)
-      link.connector('smooth');
+      link.connector('smooth')
       return link
   }
 
@@ -543,7 +544,7 @@ var py_trees = (function() {
   }
 
   /**
-   * Initialise data for a panning maneuvre. 
+   * Initialise data for a panning maneuvre.
    */
   var _pan_canvas_begin = function(paper, event, x, y) {
       console.log("PanCanvasBegin")
@@ -556,7 +557,7 @@ var py_trees = (function() {
   }
   /**
    * Pan the canvas, lookup the offset via paper.translate() later
-   * (necessary when rendering the html views, but not the models). 
+   * (necessary when rendering the html views, but not the models).
    */
   var _pan_canvas_move = function(paper, event, x, y) {
       paper.translate(
@@ -566,7 +567,7 @@ var py_trees = (function() {
   }
   /**
    * Fit the tree to the canvas if scale < 1.0,
-   * otherwise just render it normally (scale: 1.0). 
+   * otherwise just render it normally (scale: 1.0).
    */
   var _fit_content_to_canvas = function(paper, event, x, y) {
       paper.scaleContentToFit({
@@ -584,6 +585,7 @@ var py_trees = (function() {
     create_link: _create_link,
     create_node: _create_node,
     fit_content_to_canvas: _fit_content_to_canvas,
+    foo: _foo,
     layout_graph: _layout_graph,
     pan_canvas_begin: _pan_canvas_begin,
     pan_canvas_move: _pan_canvas_move,


### PR DESCRIPTION
Avoid internal storage of unnecessary _nodes, _links. Also
move paper construction and callback associations into the library.

Closes #28, closes #37 